### PR TITLE
fix: use typeof process to make sure it exists

### DIFF
--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -3,7 +3,7 @@ const URL = require('url')
 const hasUrlProtocol = /^wss:|^ws:|^\/\//
 const unsupportedProtocol = /^http:|^https:/
 
-const NODE_ENV = process && process.env && process.env.NODE_ENV
+const NODE_ENV = typeof process !== 'undefined' && process.env && process.env.NODE_ENV
 const isNode = typeof process !== 'undefined' && process.toString() === '[object process]'
 const isProduction = NODE_ENV === 'production'
 


### PR DESCRIPTION
Trying to access non-existing `process` object, such as in a browser throws an exception. This happens with webpack 5 which no longer polyfills the `process` object.