### PR TITLE
feat: more types

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "xxhash-wasm": "^1.0.2"
   },
   "devDependencies": {
+    "@types/node": "^22.10.3",
     "eslint": "^9.9.0",
     "eslint-config-prettier": "^9.1.0",
     "eslint-config-standard": "^17.1.0",

--- a/src/event/event-handler.d.ts
+++ b/src/event/event-handler.d.ts
@@ -1,0 +1,20 @@
+import { Observable } from 'rxjs'
+
+export default class EventHandler {
+  connected: boolean
+  stats: EventStats
+  subscribe: (name: string, callback: () => void) => void
+  unsubscribe: (name: string, callback: () => void) => void
+  on: (name: string, callback: () => void) => this
+  once: (name: string, callback: () => void) => this
+  off: (name: string, callback: () => void) => this
+  observe: <Data>(name: string) => Observable<Data>
+  emit: <Data>(name: string, data: Data) => void
+  provide: (pattern: string, callback: (name: string) => void, options: unknown) => () => void
+}
+
+export interface EventStats {
+  emitted: number
+  listeners: number
+  events: number
+}

--- a/src/record/record-handler.d.ts
+++ b/src/record/record-handler.d.ts
@@ -1,0 +1,157 @@
+import type { Observable } from 'rxjs'
+import Record from './record.js'
+
+type Paths<T> = keyof T
+type Get<Data, Path extends string> = Path extends keyof Data ? Data[Path] : unknown
+
+export default class RecordHandler<Records> {
+  VOID: RecordStateConstants['VOID']
+  CLIENT: RecordStateConstants['CLIENT']
+  PROVIDER: RecordStateConstants['PROVIDER']
+  SERVER: RecordStateConstants['SERVER']
+  STALE: RecordStateConstants['STALE']
+
+  JSON: {
+    // eslint-disable-next-line @typescript-eslint/no-empty-object-type
+    EMPTY: Readonly<{}>
+    // eslint-disable-next-line @typescript-eslint/no-empty-object-type
+    EMPTY_OBJ: Readonly<{}>
+    EMPTY_ARR: Readonly<unknown[]>
+  }
+
+  connected: boolean
+  stats: RecordStats
+  getRecord: <Name extends keyof Records, Data extends Records[Name] = Records[Name]>(
+    name: Name,
+  ) => Record<Data>
+
+  provide: <Data>(
+    pattern: string,
+    callback: (key: string) => Data,
+    optionsOrRecursive?: ProvideOptions | boolean,
+  ) => void | (() => void)
+
+  sync: (options?: SyncOptions) => Promise<void>
+
+  set: {
+    // without path:
+    <Name extends keyof Records>(name: Name, data: Records[Name]): void
+
+    // with path:
+    <Name extends keyof Records, Data extends Records[Name], Path extends Paths<Data>>(
+      name: Name,
+      path: Path,
+      data: Get<Data, Path>,
+    ): void
+  }
+
+  update: {
+    // without path:
+    <Name extends keyof Records, Data extends Records[Name]>(
+      name: Name,
+      updater: (data: Data) => Data,
+    ): Promise<void>
+
+    // with path:
+    <Name extends keyof Records, Data extends Records[Name], Path extends Paths<Data>>(
+      name: Name,
+      path: Path,
+      updater: (data: Get<Data, Path>) => Get<Data, Path>,
+    ): Promise<void>
+  }
+
+  observe: {
+    // without path:
+    <Name extends keyof Records, Data extends Records[Name]>(name: Name): Observable<Data>
+
+    // with path:
+    <Name extends keyof Records, Data extends Records[Name], Path extends Paths<Data> & string>(
+      name: Name,
+      path: Path,
+    ): Observable<Get<Data, Path>>
+
+    // with state:
+    <Name extends keyof Records, Data extends Records[Name]>(
+      name: Name,
+      state: RecordStateConstants,
+    ): Observable<Data>
+
+    // with path and state:
+    <Name extends keyof Records, Data extends Records[Name], Path extends Paths<Data> & string>(
+      name: Name,
+      path: Path,
+      state: number,
+    ): Observable<Get<Data, Path>>
+  }
+
+  get: {
+    // without path:
+    <Name extends keyof Records, Data extends Records[Name]>(
+      name: Name,
+      state?: number,
+    ): Promise<Data>
+
+    // with path:
+    <Name extends keyof Records, Data extends Records[Name], Path extends Paths<Data> & string>(
+      name: Name,
+      path?: Path,
+      state?: number,
+    ): Promise<Get<Data, Path>>
+  }
+
+  observe2: {
+    // without path:
+    <Name extends keyof Records, Data extends Records[Name]>(
+      name: Name,
+    ): Observable<{
+      name: Name
+      version: string
+      state: number
+      data: Data
+    }>
+
+    // with path:
+    <Name extends keyof Records, Data extends Records[Name], Path extends Paths<Data> & string>(
+      name: Name,
+      path: Path,
+    ): Observable<{
+      name: Name
+      version: Get<Data, Path>
+      state: number
+      data: Data
+    }>
+
+    // with state:
+    <Name extends keyof Records, Data extends Records[Name]>(
+      name: Name,
+      state: RecordStateConstants,
+    ): Observable<{
+      name: Name
+      version: Get<Data, Path>
+      state: number
+      data: Data
+    }>
+
+    // with path and state:
+    <Name extends keyof Records, Data extends Records[Name], Path extends Paths<Data> & string>(
+      name: Name,
+      path: Path,
+      state: number,
+    ): Observable<{
+      name: Name
+      version: Get<Data, Path>
+      state: number
+      data: Get<Data, Path>
+    }>
+  }
+}
+
+export interface RecordStats {
+  updating: number
+  created: number
+  destroyed: number
+  records: number
+  pruning: number
+  patching: number
+  subscriptions: number
+}

--- a/src/record/record.d.ts
+++ b/src/record/record.d.ts
@@ -1,0 +1,73 @@
+import RecordHandler from './record-handler.js'
+
+type Paths<T> = keyof T
+type Get<Data, Path extends string> = Path extends keyof Data ? Data[Path] : unknown
+
+export interface WhenOptions {
+  state?: number
+  timeout?: number
+  signal?: AbortSignal
+}
+
+export interface UpdateOptions {
+  signal?: AbortSignal
+}
+
+export default class Record<Data> {
+  constructor(name: string, handler: RecordHandler)
+
+  readonly name: string
+  readonly version: string
+  readonly data: Data
+  readonly state: number
+  readonly refs: number
+
+  ref(): Record<Data>
+  unref(): Record<Data>
+  subscribe(callback: (record: Record<Data>) => void, opaque?: unknown): Record<Data>
+  unsubscribe(callback: (record: Record<Data>) => void, opaque?: unknown): Record<Data>
+
+  get: {
+    // with path
+    <Path extends Paths<Data>, DataAtPath extends Get<Data, Path> = Get<Data, Path>>(
+      path: Path,
+    ): DataAtPath
+    // without path
+    (): Data
+    // implementation
+    <Path extends Paths<Data>, DataAtPath extends Get<Data, Path> = Get<Data, Path>>(
+      path?: Path,
+    ): Path extends undefined ? Data : DataAtPath
+  }
+
+  set: {
+    // with path
+    <Path extends Paths<Data>, DataAtPath extends Get<Data, Path>>(
+      path: Path,
+      dataAtPath: DataAtPath,
+    ): void
+    // without path
+    (data: Data): void
+    // implementation
+    <Path extends Paths<Data>, DataAtPath extends Get<Data, Path>>(
+      ...args: [pathOrData: Path | Data, value?: DataAtPath]
+    ): void
+  }
+
+  when: {
+    (): Promise<Record<Data>>
+    (state: number): Promise<Record<Data>>
+    (options: WhenOptions): Promise<Record<Data>>
+    (state: number, options: WhenOptions): Promise<Record<Data>>
+  }
+
+  update<Path extends Paths<Data>, PathOrUpdater extends Path | ((data: Data) => Data)>(
+    ...args: PathOrUpdater extends Path
+      ? [
+          path: Path,
+          updater: (dataAtPath: Get<Data, Path>) => Get<Data, Path>,
+          options?: UpdateOptions,
+        ]
+      : [updater: PathOrUpdater, options?: UpdateOptions]
+  ): Promise<void>
+}

--- a/src/rpc/rpc-handler.d.ts
+++ b/src/rpc/rpc-handler.d.ts
@@ -1,0 +1,31 @@
+import RpcResponse from './rpc-response.js'
+
+export type RpcMethodDef = [arguments: unknown, response: unknown]
+
+export default class RpcHandler<Methods extends Record<string, RpcMethodDef>> {
+  connected: boolean
+  stats: RpcStats
+
+  provide: <Name extends keyof Methods>(
+    name: Name,
+    callback: (args: Methods[Name][0], response: RpcResponse<Methods[Name][1]>) => void,
+  ) => UnprovideFn
+
+  unprovide: <Name extends keyof Methods>(name: Name) => void
+
+  make: {
+    <Name extends keyof Methods>(
+      name: Name,
+      args: Methods[Name][0],
+      callback: (error: unknown, response: Methods[Name][1]) => void,
+    ): void
+    <Name extends keyof Methods>(name: Name, args: Methods[Name][0]): Promise<Methods[Name][1]>
+  }
+}
+
+type UnprovideFn = () => void
+
+export interface RpcStats {
+  listeners: number
+  rpcs: number
+}

--- a/src/rpc/rpc-response.d.ts
+++ b/src/rpc/rpc-response.d.ts
@@ -1,0 +1,5 @@
+export default class RpcResponse<Data> {
+  reject: () => void
+  error: (error: Error | string) => void
+  send: (data: Data) => void
+}


### PR DESCRIPTION
Further improvement the `d.ts` files.

Now covering most of the public API coming from `record.js` and `rpc-handler.js`. Basic types for `event-handler.js` as well.

See dependent changes in https://github.com/nxtedition/nxt-lib/pull/64