### PR TITLE
refactor: move empty object and friends back to deepstream

### DIFF
--- a/src/client.test-d.ts
+++ b/src/client.test-d.ts
@@ -2,7 +2,7 @@
 import make, { type DeepstreamClient, type DeepstreamError } from './client.js'
 import { expectAssignable, expectError, expectType } from 'tsd'
 import type { Observable } from 'rxjs'
-import type { EmptyObject } from 'type-fest'
+import type { EmptyObject } from './record/resolve-type.js'
 
 interface Records extends Record<string, unknown> {
   o: {
@@ -23,11 +23,9 @@ interface Records extends Record<string, unknown> {
       }
     }
   }
-  possiblyEmpty:
-    | {
-        pe1: string
-      }
-    | EmptyObject
+  possiblyEmpty: {
+    pe1: string
+  }
   c: Circular
   m: {
     m1: string
@@ -91,7 +89,7 @@ ds.record.set(`${id}:domain`, 'd2.d3', 'test')
 expectError(ds.record.set(`${id}:domain`, 'd2.d3', 22))
 ds.record.set(`${id}:domain`, ['d2', 'd3'] as const, 'test')
 
-expectAssignable<string>(await ds.record.get(`${id}:domain`, 'd2.d3'))
+expectAssignable<string | undefined>(await ds.record.get(`${id}:domain`, 'd2.d3'))
 
 // errors
 expectError(ds.record.set('o', 'o0.o1', { o2: { o3: 0 } }))
@@ -101,31 +99,35 @@ expectError(ds.record.set('n', 'n0.x2', 22))
 expectError(ds.record.set('n', 'n1.x2', {}))
 expectError(ds.record.set('n', 'n1.n2.n3', { n4: 22 }))
 
-expectAssignable<string>(await ds.record.get('p', 'p1'))
-expectAssignable<{ name: string; version: string; state: number; data: string }>(
+expectAssignable<string | undefined>(await ds.record.get('p', 'p1'))
+expectAssignable<{ name: string; version: string; state: number; data: string | undefined }>(
   await ds.record.get2('p', 'p1'),
 )
-expectAssignable<string>(await ds.record.get('p', 'p1', { signal: new AbortController().signal }))
-expectAssignable<string>(await ds.record.get('p', { path: 'p1' }))
+expectAssignable<string | undefined>(
+  await ds.record.get('p', 'p1', { signal: new AbortController().signal }),
+)
+expectAssignable<string | undefined>(await ds.record.get('p', { path: 'p1' }))
 expectAssignable<string | undefined>(await ds.record.get('p', 'p2'))
 expectAssignable<unknown>(await ds.record.get('p', 'x1'))
 expectAssignable<string | undefined>(await ds.record.get('possiblyEmpty', 'pe1'))
 
 // observe with options
-expectAssignable<Observable<{ p1: string; p2?: string; p3: { p4: string } }>>(
+expectAssignable<Observable<{ p1: string; p2?: string; p3: { p4: string } } | EmptyObject>>(
   ds.record.observe('p', { signal: new AbortController().signal }),
 )
-expectAssignable<Observable<{ p1: string; p2?: string; p3: { p4: string } }>>(
+expectAssignable<Observable<{ p1: string; p2?: string; p3: { p4: string } } | EmptyObject>>(
   ds.record.observe('p', { timeout: 5000 }),
 )
-expectAssignable<Observable<string>>(
+expectAssignable<Observable<string | undefined>>(
   ds.record.observe('p', 'p1', { signal: new AbortController().signal }),
 )
-expectAssignable<Observable<string>>(ds.record.observe('p', { path: 'p1', timeout: 5000 }))
-expectAssignable<Observable<string>>(
+expectAssignable<Observable<string | undefined>>(
+  ds.record.observe('p', { path: 'p1', timeout: 5000 }),
+)
+expectAssignable<Observable<string | undefined>>(
   ds.record.observe('p', 'p1', 2, { signal: new AbortController().signal }),
 )
-expectAssignable<Observable<{ p1: string; p2?: string; p3: { p4: string } }>>(
+expectAssignable<Observable<{ p1: string; p2?: string; p3: { p4: string } } | EmptyObject>>(
   ds.record.observe('p', 2, { timeout: 5000 }),
 )
 
@@ -135,7 +137,7 @@ expectAssignable<
     name: string
     version: string
     state: number
-    data: { p1: string; p2?: string; p3: { p4: string } }
+    data: { p1: string; p2?: string; p3: { p4: string } } | EmptyObject
   }>
 >(ds.record.observe2('p', { signal: new AbortController().signal }))
 expectAssignable<
@@ -143,7 +145,7 @@ expectAssignable<
     name: string
     version: string
     state: number
-    data: { p1: string; p2?: string; p3: { p4: string } }
+    data: { p1: string; p2?: string; p3: { p4: string } } | EmptyObject
   }>
 >(ds.record.observe2('p', { timeout: 5000 }))
 expectAssignable<
@@ -151,7 +153,7 @@ expectAssignable<
     name: string
     version: string
     state: number
-    data: string
+    data: string | undefined
   }>
 >(ds.record.observe2('p', 'p1', { signal: new AbortController().signal }))
 expectAssignable<
@@ -159,7 +161,7 @@ expectAssignable<
     name: string
     version: string
     state: number
-    data: string
+    data: string | undefined
   }>
 >(ds.record.observe2('p', { path: 'p1', timeout: 5000 }))
 expectAssignable<
@@ -167,7 +169,7 @@ expectAssignable<
     name: string
     version: string
     state: number
-    data: string
+    data: string | undefined
   }>
 >(ds.record.observe2('p', 'p1', 2, { signal: new AbortController().signal }))
 expectAssignable<
@@ -175,7 +177,7 @@ expectAssignable<
     name: string
     version: string
     state: number
-    data: { p1: string; p2?: string; p3: { p4: string } }
+    data: { p1: string; p2?: string; p3: { p4: string } } | EmptyObject
   }>
 >(ds.record.observe2('p', 2, { timeout: 5000 }))
 

--- a/src/record/record-handler.d.ts
+++ b/src/record/record-handler.d.ts
@@ -1,8 +1,7 @@
 import type { Observable } from 'rxjs'
+import type { RecordNameToType, RecordPathToType, RecordPathToWriteType } from './resolve-type.d.ts'
 import type DsRecord from './record.js'
-import type { Get, UpdateOptions, ObserveOptions, ObserveOptionsWithPath } from './record.js'
-
-type Lookup<Table, Name> = Name extends keyof Table ? Table[Name] : unknown
+import type { UpdateOptions, ObserveOptions, ObserveOptionsWithPath } from './record.js'
 
 export default class RecordHandler<Records = Record<string, unknown>> {
   VOID: 0
@@ -29,7 +28,7 @@ export default class RecordHandler<Records = Record<string, unknown>> {
   connected: boolean
   stats: RecordStats
 
-  getRecord<Name extends string, Data = Lookup<Records, Name>>(name: Name): DsRecord<Data>
+  getRecord<Name extends string, Data = RecordNameToType<Records, Name>>(name: Name): DsRecord<Data>
 
   provide: (
     pattern: string,
@@ -49,45 +48,46 @@ export default class RecordHandler<Records = Record<string, unknown>> {
       name: Name,
       options: ObserveOptions,
     ):
-      | { value: Lookup<Records, Name>; async: false }
-      | { value: Promise<Lookup<Records, Name>>; async: true }
+      | { value: RecordNameToType<Records, Name>; async: false }
+      | { value: Promise<RecordNameToType<Records, Name>>; async: true }
 
     <Name extends string, Path extends string | string[]>(
       name: Name,
       path: Path,
       options?: ObserveOptions,
     ):
-      | { value: Get<Lookup<Records, Name>, Path>; async: false }
-      | { value: Promise<Get<Lookup<Records, Name>, Path>>; async: true }
+      | { value: RecordPathToType<Records, Name, Path>; async: false }
+      | { value: Promise<RecordPathToType<Records, Name, Path>>; async: true }
 
     <Name extends string>(
       name: Name,
       state?: number,
     ):
-      | { value: Lookup<Records, Name>; async: false }
-      | { value: Promise<Lookup<Records, Name>>; async: true }
+      | { value: RecordNameToType<Records, Name>; async: false }
+      | { value: Promise<RecordNameToType<Records, Name>>; async: true }
   }
 
   sync: (options?: SyncOptions) => Promise<void>
 
   set: {
     // without path:
-    <Name extends string>(name: Name, data: Lookup<Records, Name>): void
+    <Name extends string>(name: Name, data: RecordNameToType<Records, Name>): void
 
     // with path:
     <Name extends string, Path extends string | string[]>(
       name: Name,
       path: Path,
-      data: unknown extends Get<Lookup<Records, Name>, Path>
-        ? never
-        : Get<Lookup<Records, Name>, Path>,
+      data: RecordPathToWriteType<Records, Name, Path>,
     ): void
   }
 
   update: {
     <Name extends string>(
       name: Name,
-      updater: (data: Lookup<Records, Name>, version: string) => Lookup<Records, Name>,
+      updater: (
+        data: RecordNameToType<Records, Name>,
+        version: string,
+      ) => RecordNameToType<Records, Name>,
       options?: UpdateOptions,
     ): Promise<void>
 
@@ -95,45 +95,48 @@ export default class RecordHandler<Records = Record<string, unknown>> {
       name: Name,
       path: Path,
       updater: (
-        data: Get<Lookup<Records, Name>, Path>,
+        data: RecordPathToType<Records, Name, Path>,
         version: string,
-      ) => Get<Lookup<Records, Name>, Path>,
+      ) => RecordPathToType<Records, Name, Path>,
       options?: UpdateOptions,
     ): Promise<void>
   }
 
   observe: {
-    <Name extends string>(name: Name, options: ObserveOptions): Observable<Lookup<Records, Name>>
+    <Name extends string>(
+      name: Name,
+      options: ObserveOptions,
+    ): Observable<RecordNameToType<Records, Name>>
 
     <Name extends string, Path extends string | string[]>(
       name: Name,
       options: ObserveOptionsWithPath<Path>,
-    ): Observable<Get<Lookup<Records, Name>, Path>>
+    ): Observable<RecordPathToType<Records, Name, Path>>
 
     <Name extends string>(
       name: Name,
       state?: number,
       options?: ObserveOptions,
-    ): Observable<Lookup<Records, Name>>
+    ): Observable<RecordNameToType<Records, Name>>
 
     <Name extends string, Path extends string | string[]>(
       name: Name,
       state?: number,
       options?: ObserveOptionsWithPath<Path>,
-    ): Observable<Get<Lookup<Records, Name>, Path>>
+    ): Observable<RecordPathToType<Records, Name, Path>>
 
     <Name extends string, Path extends string | string[]>(
       name: Name,
       path: Path,
       options?: ObserveOptionsWithPath<Path>,
-    ): Observable<Get<Lookup<Records, Name>, Path>>
+    ): Observable<RecordPathToType<Records, Name, Path>>
 
     <Name extends string, Path extends string | string[]>(
       name: Name,
       path: Path,
       state?: number,
       options?: ObserveOptionsWithPath<Path>,
-    ): Observable<Get<Lookup<Records, Name>, Path>>
+    ): Observable<RecordPathToType<Records, Name, Path>>
   }
 
   observe2: {
@@ -144,7 +147,7 @@ export default class RecordHandler<Records = Record<string, unknown>> {
       name: string
       version: string
       state: number
-      data: Lookup<Records, Name>
+      data: RecordNameToType<Records, Name>
     }>
 
     <Name extends string, Path extends string | string[]>(
@@ -154,7 +157,7 @@ export default class RecordHandler<Records = Record<string, unknown>> {
       name: string
       version: string
       state: number
-      data: Get<Lookup<Records, Name>, Path>
+      data: RecordPathToType<Records, Name, Path>
     }>
 
     <Name extends string>(
@@ -165,7 +168,7 @@ export default class RecordHandler<Records = Record<string, unknown>> {
       name: string
       version: string
       state: number
-      data: Lookup<Records, Name>
+      data: RecordNameToType<Records, Name>
     }>
 
     <Name extends string, Path extends string | string[]>(
@@ -176,7 +179,7 @@ export default class RecordHandler<Records = Record<string, unknown>> {
       name: string
       version: string
       state: number
-      data: Get<Lookup<Records, Name>, Path>
+      data: RecordPathToType<Records, Name, Path>
     }>
 
     <Name extends string, Path extends string | string[]>(
@@ -187,7 +190,7 @@ export default class RecordHandler<Records = Record<string, unknown>> {
       name: string
       version: string
       state: number
-      data: Get<Lookup<Records, Name>, Path>
+      data: RecordPathToType<Records, Name, Path>
     }>
 
     <Name extends string, Path extends string | string[]>(
@@ -199,42 +202,45 @@ export default class RecordHandler<Records = Record<string, unknown>> {
       name: string
       version: string
       state: number
-      data: Get<Lookup<Records, Name>, Path>
+      data: RecordPathToType<Records, Name, Path>
     }>
   }
 
   get: {
-    <Name extends string>(name: Name, options: ObserveOptions): Promise<Lookup<Records, Name>>
+    <Name extends string>(
+      name: Name,
+      options: ObserveOptions,
+    ): Promise<RecordNameToType<Records, Name>>
 
     <Name extends string, Path extends string | string[]>(
       name: Name,
       options: ObserveOptionsWithPath<Path>,
-    ): Promise<Get<Lookup<Records, Name>, Path>>
+    ): Promise<RecordPathToType<Records, Name, Path>>
 
     <Name extends string>(
       name: Name,
       state?: number,
       options?: ObserveOptions,
-    ): Promise<Lookup<Records, Name>>
+    ): Promise<RecordNameToType<Records, Name>>
 
     <Name extends string, Path extends string | string[]>(
       name: Name,
       state?: number,
       options?: ObserveOptionsWithPath<Path>,
-    ): Promise<Get<Lookup<Records, Name>, Path>>
+    ): Promise<RecordPathToType<Records, Name, Path>>
 
     <Name extends string, Path extends string | string[]>(
       name: Name,
       path: Path,
       options?: ObserveOptionsWithPath<Path>,
-    ): Promise<Get<Lookup<Records, Name>, Path>>
+    ): Promise<RecordPathToType<Records, Name, Path>>
 
     <Name extends string, Path extends string | string[]>(
       name: Name,
       path: Path,
       state?: number,
       options?: ObserveOptionsWithPath<Path>,
-    ): Promise<Get<Lookup<Records, Name>, Path>>
+    ): Promise<RecordPathToType<Records, Name, Path>>
   }
 
   get2: {
@@ -245,7 +251,7 @@ export default class RecordHandler<Records = Record<string, unknown>> {
       name: string
       version: string
       state: number
-      data: Lookup<Records, Name>
+      data: RecordNameToType<Records, Name>
     }>
 
     <Name extends string, Path extends string | string[]>(
@@ -255,7 +261,7 @@ export default class RecordHandler<Records = Record<string, unknown>> {
       name: string
       version: string
       state: number
-      data: Get<Lookup<Records, Name>, Path>
+      data: RecordPathToType<Records, Name, Path>
     }>
 
     <Name extends string>(
@@ -266,7 +272,7 @@ export default class RecordHandler<Records = Record<string, unknown>> {
       name: string
       version: string
       state: number
-      data: Lookup<Records, Name>
+      data: RecordNameToType<Records, Name>
     }>
 
     <Name extends string, Path extends string | string[]>(
@@ -277,7 +283,7 @@ export default class RecordHandler<Records = Record<string, unknown>> {
       name: string
       version: string
       state: number
-      data: Get<Lookup<Records, Name>, Path>
+      data: RecordPathToType<Records, Name, Path>
     }>
 
     <Name extends string, Path extends string | string[]>(
@@ -288,7 +294,7 @@ export default class RecordHandler<Records = Record<string, unknown>> {
       name: string
       version: string
       state: number
-      data: Get<Lookup<Records, Name>, Path>
+      data: RecordPathToType<Records, Name, Path>
     }>
 
     <Name extends string, Path extends string | string[]>(
@@ -300,7 +306,7 @@ export default class RecordHandler<Records = Record<string, unknown>> {
       name: string
       version: string
       state: number
-      data: Get<Lookup<Records, Name>, Path>
+      data: RecordPathToType<Records, Name, Path>
     }>
   }
 }

--- a/src/record/record.d.ts
+++ b/src/record/record.d.ts
@@ -1,15 +1,6 @@
 import type RecordHandler from './record-handler.js'
-import type { Get as _Get, AllUnionFields } from 'type-fest'
-export type { Paths } from 'type-fest'
-
-// HACK: Wrap type-fest's Get to get rid of EmptyObject from union
-type RemoveSymbolKeys<T> = {
-  [K in keyof T as K extends symbol ? never : K]: T[K]
-}
-export type Get<BaseType, Path extends string | readonly string[]> = _Get<
-  RemoveSymbolKeys<AllUnionFields<BaseType>>,
-  Path
->
+import type { Get } from 'type-fest'
+export type { Get, Paths } from 'type-fest'
 
 export interface WhenOptions {
   signal?: AbortSignal

--- a/src/record/resolve-type.d.ts
+++ b/src/record/resolve-type.d.ts
@@ -1,0 +1,57 @@
+import type { Get, SingleKeyObject } from 'type-fest'
+
+declare const emptyObjectSymbol: unique symbol
+export type EmptyObject = { [emptyObjectSymbol]?: never }
+
+// When getting, for convenience, we say the data might be partial under some
+// circumstances.
+//
+// When you e.g. do record.get or record.update, there is always a possibility
+// that the data object is empty. The naive correct type for that would be
+// `Data | EmptyObject`. However, that forces the user to always type guard
+// against the empty object case. This type tries to allow the user to skip
+// that check in some cases, where it should be safe to do so.
+type GettablePossibleEmpty<Data> = keyof Data extends never
+  ? EmptyObject
+  : // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    Partial<Data> & { [key: string]: any } extends Data
+    ? Data
+    : SingleKeyObject<Data> extends never
+      ? Data | EmptyObject
+      : {
+          [K in keyof Data]+?: Data[K]
+        }
+
+/**
+ * Maps a record name + path to the type used when reading.
+ * Unknown records give 'unknown'.
+ *
+ * Unset records are represented with the 'EmptyObject' type.
+ */
+export type RecordNameToType<Table, Name> = Name extends keyof Table
+  ? GettablePossibleEmpty<Table[Name]>
+  : unknown
+
+/**
+ * Maps a record name + path to the type used when reading.
+ * Unknown records give 'unknown'.
+ */
+export type RecordPathToType<
+  Table,
+  Name,
+  Path extends string | readonly string[],
+> = Name extends keyof Table ? Get<Table[Name], Path> | undefined : unknown
+
+/**
+ * Maps a record name + path to the type used when writing.
+ * Unknown records give 'never'.
+ */
+export type RecordPathToWriteType<
+  Table,
+  Name,
+  Path extends string | readonly string[],
+> = Name extends keyof Table
+  ? unknown extends Get<Table[Name], Path>
+    ? never
+    : Get<Table[Name], Path>
+  : never


### PR DESCRIPTION
Originally, the types needed for mapping record id -> record type where defined in `@nxtedition/deepstream.io-client-js`. They where later moved to `@nxtedition/types` as they where needed there as well. Because of this the deepstream typings are incorrect for some cases.

This PR moves the types back to deepstream and `@nxtedition/types` will be updated to depend on deepstream.

Note that it's not possible to just duplicate the code into deepstream and types because `EmptyObject` is uniquely defined and will cause conflicts. This is the reason for the peerDependencies - if a package depend on both deepstream and types, they must agree on the same version for `@nxtedition/deepstream.io-resolve-type`.